### PR TITLE
Fixes compilation errors

### DIFF
--- a/PrinterConvert.c
+++ b/PrinterConvert.c
@@ -540,11 +540,11 @@ int write_png(const char *filename, int width, int height, char *rgb)
     int ipos, data_found = 0, end_loop = 0;
     unsigned char pixelColour;
     int code = 1;
-    if (imageMode == 2 ) {
-        png_structp png_ptr = NULL;
-        png_infop info_ptr = NULL;
-        png_bytep row = NULL;
-    }
+    //Used only if (imageMode == 2 )
+    png_structp png_ptr = NULL;
+    png_infop info_ptr = NULL;
+    png_bytep row = NULL;
+    //
     FILE *file = NULL;
 
     // Check if a blank page - if so ignore it!
@@ -2667,10 +2667,10 @@ main_loop_for_printing:
                             state = read_byte_from_printer((char *) &mH);
                             if (state == 0) break;
                             pageManagementUnit = ((float) m1 / (float) ((mH * 256) + mL) * printerdpiv);
-                            relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;
-                            absVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;
-                            relHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv;
-                            absHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv;
+                            relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv);
+                            absVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv);
+                            relHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv);
+                            absHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv);
                         }
                         break;
                     case 'i':
@@ -3754,10 +3754,10 @@ main_loop_for_printing:
                             state = read_byte_from_printer((char *) &mH);
                             if (state == 0) break;
                             pageManagementUnit = ((float) m1 / (float) ((mH * 256) + mL) * printerdpiv);
-                            relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;
-                            absVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;
-                            relHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv;
-                            absHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv;
+                            relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv);
+                            absVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv);
+                            relHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv);
+                            absHorizontalUnit = ((float) m3 / (float) ((mH * 256) + mL) * printerdpiv);
                         }
                         break;
                     case 'i':


### PR DESCRIPTION
PrinterConvert.c: In function ‘write_png’:
PrinterConvert.c:587:9: error: ‘png_ptr’ undeclared (first use in this function)
         png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
         ^
PrinterConvert.c:587:9: note: each undeclared identifier is reported only once for each function it appears in
PrinterConvert.c:594:9: error: ‘info_ptr’ undeclared (first use in this function)
         info_ptr = png_create_info_struct(png_ptr);
         ^
PrinterConvert.c:621:9: error: ‘row’ undeclared (first use in this function)
         row = (png_bytep) malloc(3 * width * sizeof(png_byte));

PrinterConvert.c:2667:100: error: expected ‘)’ before ‘;’ token
                             relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;

PrinterConvert.c:3755:100: error: expected ‘)’ before ‘;’ token
                             relVerticalUnit = ((float) m2 / (float) ((mH * 256) + mL) * printerdpiv;