### PR TITLE
allow compilation on 64 bit arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,23 @@ INSTALL = install -c
 INSTALL_PRG = $(INSTALL)
 INSTALL_DATA = $(INSTALL) -m 644
 
-ifneq ($(shell uname -p),x86_64)
+ifeq ($(shell uname -m),x86_64)
+CFLAGS = -O3 \
+         -funsafe-math-optimizations \
+         $(shell sdl-config --cflags)
+else
+ifeq ($(shell uname -m),aarch64)
+CFLAGS = -O3 \
+         -funsafe-math-optimizations \
+         $(shell sdl-config --cflags)
+else
+# fallback on 32bit Raspberry PI ARM options
 CFLAGS = -O3 \
          -mfloat-abi=hard \
          -funsafe-math-optimizations \
          -mno-unaligned-access \
          $(shell sdl-config --cflags)
-else
-CFLAGS = -O3 \
-         -funsafe-math-optimizations \
-         $(shell sdl-config --cflags)
+endif
 endif
 
 LDFLAGS = $(shell sdl-config --libs)


### PR DESCRIPTION
Tweak the Makefile to use uname -m instead of the non-standard uname -p. Debian doesn't support uname -p. Only a few commercial Linux variants do, and maybe consequently centos.

X86_64 and aarch64 will skip use of the ARM 32 bit specific CFLAGS